### PR TITLE
try: artifact attestations

### DIFF
--- a/.github/workflows/artifact-attestations.yaml
+++ b/.github/workflows/artifact-attestations.yaml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    paths:
+      - .github/workflows/artifact-attestations.yaml
+
+jobs:
+  attestation:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - run: date > date.txt
+      
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "date.txt"
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: date.txt


### PR DESCRIPTION
Introducing Artifact Attestations–now in public beta - The GitHub Blog
https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/

---

# Sign
<img width="1451" alt="image" src="https://github.com/korosuke613/playground/assets/20027695/fa3746e0-dd09-4877-87fc-80c037ddd6c7">

https://github.com/korosuke613/playground/actions/runs/9205480656?pr=57

<img width="1378" alt="image" src="https://github.com/korosuke613/playground/assets/20027695/81ec9b2d-bcea-44f5-b5ba-6d25d79baac2">

https://github.com/korosuke613/playground/actions/runs/9205480656/job/25321247301?pr=57

<img width="2028" alt="image" src="https://github.com/korosuke613/playground/assets/20027695/96026c46-dad7-468a-8802-c6e90efa631d">

https://github.com/korosuke613/playground/attestations/897669

# Verify

```console
❯ unzip build-artifacts.zip
Archive:  build-artifacts.zip
  inflating: date.txt

❯ gh attestation verify ./date.txt -R korosuke613/playground
Loaded digest sha256:9a389964bdad159bc99cacd0a589213ed3042a61b6cce91d2a4edd5823a925ae for file://date.txt
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:9a389964bdad159bc99cacd0a589213ed3042a61b6cce91d2a4edd5823a925ae was attested by:
REPO                    PREDICATE_TYPE                  WORKFLOW
korosuke613/playground  https://slsa.dev/provenance/v1  .github/workflows/artifact-attestations.yaml@refs/pull/57/merge
```